### PR TITLE
Add queue to status when using battlemetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can run it on windows, macOS, linux or docker, se the installation for more 
 # Configuration
 config.json
 ```
-{ 
+{
   "debug" : false,
   "token"  : "your token here",
   "apiSite" : 1,
@@ -34,7 +34,8 @@ config.json
   "rconport"   : "",
   "rconpass"   : "",
   "prefix" : "!",
-  "roles"  :  ["Administrator", "admins"]
+  "roles"  :  ["Administrator", "admins"],
+  "queueMessage"  :  "currently waiting in queue."
 }
 ```
 * token = Your bot token from discord.
@@ -46,6 +47,7 @@ config.json
 * https://api.battlemetrics.com/servers/2559877 (add your serverid)
 * Client secret is used to invite the bot to your server. Token is used for the bot to connect to discord.
 * enableRcon must be 1 if you want to use rcon to send commands to your server.
+* queueMessage message to display after queue number. Only available using battlemetrics.
 
 # Installation:
 * Requires node ^8.0, runs on windows, macOS, linux and docker.
@@ -56,7 +58,7 @@ config.json
 3. Run command: npm install (This downloads the require modules from package.json)
   3.  a: You can manualy do this with command: npm install discord.js request ws
   3.  b: You should now see that you have a new folder node_modules.
-4. Open config.json and add your token from (Do not use client secret) https://discordapp.com/developers/applications/me/ 
+4. Open config.json and add your token from (Do not use client secret) https://discordapp.com/developers/applications/me/
 ![Discord-bot-token](https://i.gyazo.com/7a19e5d13171f192e0ea6de3a607777a.png)
 5. Now we can start the bot with command: node app.js and you should see that the bot is started, wait 6 min, and the status should be updated.
 

--- a/app.js
+++ b/app.js
@@ -4,11 +4,12 @@ const config = require("./config.json");
 const rcon = require("./rcon/app.js");
 
 const debug = process.env.debug || config.debug;
-const apiUrl = process.env.apiUrl || config.apiUrl; 
+const apiUrl = process.env.apiUrl || config.apiUrl;
 const apiSite = process.env.apiSite || config.apiSite;
 const enableRcon = process.env.enableRcon || config.enableRcon;
 const prefix = process.env.prefix || config.prefix;
 const roles = process.env.roles || config.roles;
+const queueMessage = proccess.env.queueMessage || config.queueMessage
 
 const updateInterval = (1000 * 60) * 3;
 
@@ -58,8 +59,13 @@ function updateActivity() {
                 if (is_online == "online") {
                     const players = server.players;
                     const maxplayers = server.maxPlayers;
+                    const queue = server.details.rust_queued_players;
+                    let status = `${players}/${maxplayers}`;
+                    if (queue != "0") {
+                        status += ` (${queue} ${queueMessage})`;
+                    }
                     if (debug) console.log("Updated from battlemetrics, serverid: " + server.id);
-                    return client.user.setActivity(`${players}/${maxplayers}`);
+                    return client.user.setActivity(status);
                 } else {
                     return client.user.setActivity("Offline");
                 }
@@ -82,28 +88,28 @@ if (enableRcon == 1) {
 
       if(message.author.bot) return;
       if(message.content.indexOf(prefix) !== 0) return;
-    
+
       var args = message.content.slice(prefix.length).trim().split(/ +/g);
       var command = args.shift().toLowerCase();
-    
+
     if(command === "rcon") {
       // Checks for discord permission
       if(!message.member.roles.some(r=>roles.includes(r.name)) )
         return message.reply("Sorry, you don't have permissions to use this!");
-    
+
       var getMessage = args.join(" ");
-      
+
       // Rcon message.
       argumentString = `${getMessage}`;
-      
+
       // Rcon Config
       rconhost = process.env.rconhost || config.rconhost;
       rconport = process.env.rconport || config.rconport;
       rconpass = process.env.rconpass || config.rconpass;
-      
+
       // Run rcon command.
       rcon.RconApp(argumentString, rconhost, rconport,rconpass, debug);
-      
+
       // Send message back to discord that we are trying to relay the command.
       message.channel.send(`Trying to relay command: ${getMessage}`);
       }

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
-{ 
+{
   "debug" : false,
   "token"  : "your token here",
   "apiSite" : 1,
@@ -8,5 +8,6 @@
   "rconport"   : "",
   "rconpass"   : "",
   "prefix" : "!",
-  "roles"  :  ["Administrator", "admins"]
+  "roles"  :  ["Administrator", "admins"],
+  "queueMessage"  :  "currently waiting in queue."
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,4 @@ services:
       - rconpass="yourpassword"
       - prefix="!"
       - roles="Administrator"
+      - quoteMessage="currently waiting in queue."


### PR DESCRIPTION
Added the ability to see players waiting in queue in status while using battlemetrics. Did not implement this with other api modes because they do not expose the metric.

PS: sorry about the removed white space changes. Looks like my linter was hard at work.