### PR TITLE
Make sure queue is defined before displaying it

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@ fs.readdir(configdir, (err, files) => {
                             const maxplayers = server.maxPlayers
                             const queue = server.details.rust_queued_players
                             let status = `${players}/${maxplayers}`
-                            if (queue != "0") {
+                            if (typeof queue !== "undefined" && queue != "0") {
                                 status += ` (${queue} ${queueMessage})`
                             }
                             if (debug) console.log("Updated from battlemetrics, serverid: " + server.id)


### PR DESCRIPTION
While I understand this project predominantly is for Rust, I am using it for something else and this field doesn't exist. This results in an `undefined` alongside the queue message. Simple PR that just checks whether this field exists before appending it to the bot status.